### PR TITLE
Enhance fullscreen template to support video handling in slideshow

### DIFF
--- a/templates/fullscreen.tmpl
+++ b/templates/fullscreen.tmpl
@@ -176,7 +176,8 @@
         let isDragging = false;
         let currentUrl = window.location.href;
         let slideshowTimer = null;
-        let slideshowInterval = {{.SlideshowInterval}}; 
+        let slideshowInterval = {{.SlideshowInterval}};
+        let isVideo = {{.IsVideo}}; 
 
         // Touch/swipe navigation
         document.addEventListener('touchstart', function(e) {
@@ -285,12 +286,15 @@
         }
 
         function startSlideshow() {
-            // Only start slideshow if there's a next item available
-            const nextButton = document.querySelector('.nav-button.next');
-            if (nextButton && !nextButton.disabled) {
-                slideshowTimer = setTimeout(() => {
-                    navigateTo('{{.NextUrl}}');
-                }, slideshowInterval);
+            // Only start slideshow timer for images, not videos
+            if (!isVideo) {
+                // Only start slideshow if there's a next item available
+                const nextButton = document.querySelector('.nav-button.next');
+                if (nextButton && !nextButton.disabled) {
+                    slideshowTimer = setTimeout(() => {
+                        navigateTo('{{.NextUrl}}');
+                    }, slideshowInterval);
+                }
             }
         }
 
@@ -303,7 +307,10 @@
 
         function resetSlideshowTimer() {
             clearSlideshowTimer();
-            startSlideshow();
+            // Only restart slideshow for images, not videos
+            if (!isVideo) {
+                startSlideshow();
+            }
         }
 
         // Prevent context menu on image
@@ -311,14 +318,47 @@
             e.preventDefault();
         });
 
+        // Handle video events
+        function setupVideoHandling() {
+            if (isVideo) {
+                const video = document.querySelector('.fullscreen-video');
+                if (video) {
+                    // Auto-play the video
+                    video.play().catch(e => {
+                        console.log('Video autoplay failed:', e);
+                    });
+                    
+                    // Advance to next slide when video ends
+                    video.addEventListener('ended', function() {
+                        const nextButton = document.querySelector('.nav-button.next');
+                        if (nextButton && !nextButton.disabled) {
+                            navigateTo('{{.NextUrl}}');
+                        }
+                    });
+                    
+                    // Reset slideshow timer on video interaction
+                    video.addEventListener('play', function() {
+                        clearSlideshowTimer();
+                    });
+                    
+                    video.addEventListener('pause', function() {
+                        clearSlideshowTimer();
+                    });
+                }
+            }
+        }
+
         // Start the slideshow when the page loads
         document.addEventListener('DOMContentLoaded', function() {
+            setupVideoHandling();
             startSlideshow();
         });
 
-        // Also handle mouse movement to reset timer (optional - for more responsive UX)
+        // Also handle mouse movement to reset timer (only for images)
         document.addEventListener('mousemove', function(e) {
-            resetSlideshowTimer();
+            if (!isVideo) {
+                resetSlideshowTimer();
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
- Introduced `isVideo` variable to differentiate between images and videos.
- Modified slideshow logic to only start for images, while videos autoplay and advance to the next slide upon completion.
- Added event listeners for video play and pause to manage slideshow timer effectively.
- Updated DOMContentLoaded event to initialize video handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds video handling to `templates/fullscreen.tmpl`: videos autoplay, advance on end, and disable image slideshow timers; image slideshow behavior unchanged.
> 
> - **Fullscreen template (`templates/fullscreen.tmpl`)**:
>   - Introduce `isVideo` flag exposed to JS (`let isVideo = {{.IsVideo}}`).
>   - Slideshow timing:
>     - `startSlideshow` and `resetSlideshowTimer` now run only for images (`!isVideo`).
>     - Mousemove timer reset limited to images.
>   - Video handling (`setupVideoHandling`):
>     - Autoplay `.fullscreen-video` on load.
>     - On `ended`, navigate to `{{.NextUrl}}` if available.
>     - On `play`/`pause`, clear slideshow timer.
>   - Initialize on load: call `setupVideoHandling()` in `DOMContentLoaded`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12dfd2cfe0afb8b728be6c91fce50d5c36746ab9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->